### PR TITLE
fix calculate next run

### DIFF
--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -6,7 +6,7 @@ class ScheduledTasksChecker
          issue.save         
          interval = task.interval_number
          units = task.interval_units
-         task.next_run_date =  interval.send(units.downcase).from_now
+         task.next_run_date =  (task.next_run_date || Time.now) + interval.send(units.downcase)
          task.save
      end
   end


### PR DESCRIPTION
I have a task with next date set, say, to 2015-01-29 12:00:00. When cron job runs every hour, next run time is set to something like 2015-01-30 12:00:30 (seconds depend on cron job run time) and tomorrow task really run at 13:00
issue #5 
